### PR TITLE
Draft: 動画を VideosTab -> Newsfeed の順で公開できるように修正

### DIFF
--- a/src/apis/post_video.rs
+++ b/src/apis/post_video.rs
@@ -80,7 +80,7 @@ impl Fbapi {
         )
         .await?;
 
-        post_to_video_tab(
+        post_to_videos_tab(
             &self.make_path(&fbid),
             access_token,
             retry_count,
@@ -187,7 +187,7 @@ async fn post(
     .await
 }
 
-async fn post_to_video_tab(
+async fn post_to_videos_tab(
     path: &str,
     access_token: &str,
     retry_count: usize,

--- a/src/apis/post_video.rs
+++ b/src/apis/post_video.rs
@@ -44,9 +44,8 @@ impl Fbapi {
         .await
     }
 
-    /// 直接 Newsfeed に投稿できない現象が発生している
-    /// 一度 VideosTab に公開してから Newsfeed に公開する
-    /// （この現象が発生しなくなったらこのメソッドは削除できる）
+    /// 直接 Newsfeed に投稿できない現象が発生している。
+    /// 一度 VideosTab に公開してから Newsfeed に公開する。
     pub async fn post_video_via_videos_tab(
         &self,
         access_token: &str,


### PR DESCRIPTION
fb 動画の公開に失敗する現象が発生しています。

```json
{
  "code": 200,
  "error_subcode": 1363122,
  "error_user_msg": "There was a problem publishing this video to newsfeed.",
  "error_user_title": "Video Not Published to Newsfeed",
  "is_transient": false,
  "message": "Permissions error",
  "type": "OAuthException"
}
```

[ドキュメント](https://developers.facebook.com/docs/graph-api/reference/video/)に記載はないですが、以下のような挙動になっているようです。

- 【今の方法・失敗する】動画アップロード -> Newsfeed に公開
- 【新しく追加する方法・成功する】動画アップロード -> VideosTab に公開 -> Newsfeed に公開

下の方法でも動画を公開できるように修正しました。
