### PR TITLE
Instagramカルーセルに対応する

### DIFF
--- a/src/apis.rs
+++ b/src/apis.rs
@@ -4,6 +4,7 @@ pub mod get_object;
 pub mod post_album_photo;
 pub mod post_batch;
 pub mod post_feed_array;
+pub mod post_ig_carousel;
 pub mod post_ig_picture;
 pub mod post_ig_video;
 pub mod post_object;

--- a/src/apis.rs
+++ b/src/apis.rs
@@ -1,3 +1,4 @@
+pub mod check_ig_media;
 pub mod create_album;
 pub mod delete_object;
 pub mod get_object;

--- a/src/apis.rs
+++ b/src/apis.rs
@@ -6,6 +6,7 @@ pub mod post_album_photo;
 pub mod post_batch;
 pub mod post_feed_array;
 pub mod post_ig_carousel;
+pub mod post_ig_media_publish;
 pub mod post_ig_picture;
 pub mod post_ig_video;
 pub mod post_object;

--- a/src/apis/check_ig_media.rs
+++ b/src/apis/check_ig_media.rs
@@ -1,0 +1,43 @@
+use crate::*;
+
+async fn check_ig_media(
+    path: &str,
+    retry_count: usize,
+    client: &reqwest::Client,
+    log: &impl Fn(LogParams),
+) -> Result<String, FbapiError> {
+    let log_params = LogParams::new(&path, &vec![]);
+    let res = execute_retry(
+        retry_count,
+        || async { client.get(path).send().await.map_err(|e| e.into()) },
+        log,
+        log_params,
+    )
+    .await?;
+    match res["status_code"].as_str() {
+        Some(s) => Ok(s.to_owned()),
+        None => return Err(FbapiError::UnExpected(res)),
+    }
+}
+
+pub(crate) async fn check_ig_media_loop(
+    path: &str,
+    check_retry_count: usize,
+    check_video_delay: usize,
+    retry_count: usize,
+    client: &reqwest::Client,
+    log: &impl Fn(LogParams),
+) -> Result<(), FbapiError> {
+    for _ in 0..check_retry_count {
+        match check_ig_media(path, retry_count, client, log)
+            .await?
+            .as_str()
+        {
+            "FINISHED" => return Ok(()),
+            "IN_PROGRESS" => {}
+            _ => return Err(FbapiError::VideoError),
+        }
+        sleep(check_video_delay).await;
+    }
+    Err(FbapiError::VideoTimeout)
+}

--- a/src/apis/post_ig_carousel.rs
+++ b/src/apis/post_ig_carousel.rs
@@ -1,3 +1,4 @@
+use crate::apis::check_ig_media::check_ig_media_loop;
 use crate::*;
 
 impl Fbapi {
@@ -23,7 +24,7 @@ impl Fbapi {
         )
         .await?;
 
-        check_loop(
+        check_ig_media_loop(
             &self.make_path(&format!(
                 "{}?fields=status_code&access_token={}",
                 creation_id, access_token
@@ -83,45 +84,6 @@ async fn post(
         Some(s) => Ok(s.to_owned()),
         None => return Err(FbapiError::UnExpected(res)),
     }
-}
-
-async fn check(
-    path: &str,
-    retry_count: usize,
-    client: &reqwest::Client,
-    log: &impl Fn(LogParams),
-) -> Result<String, FbapiError> {
-    let log_params = LogParams::new(&path, &vec![]);
-    let res = execute_retry(
-        retry_count,
-        || async { client.get(path).send().await.map_err(|e| e.into()) },
-        log,
-        log_params,
-    )
-    .await?;
-    match res["status_code"].as_str() {
-        Some(s) => Ok(s.to_owned()),
-        None => return Err(FbapiError::UnExpected(res)),
-    }
-}
-
-async fn check_loop(
-    path: &str,
-    check_retry_count: usize,
-    check_video_delay: usize,
-    retry_count: usize,
-    client: &reqwest::Client,
-    log: &impl Fn(LogParams),
-) -> Result<(), FbapiError> {
-    for _ in 0..check_retry_count {
-        match check(path, retry_count, client, log).await?.as_str() {
-            "FINISHED" => return Ok(()),
-            "IN_PROGRESS" => {}
-            _ => return Err(FbapiError::VideoError),
-        }
-        sleep(check_video_delay).await;
-    }
-    Err(FbapiError::VideoTimeout)
 }
 
 async fn publish(

--- a/src/apis/post_ig_carousel.rs
+++ b/src/apis/post_ig_carousel.rs
@@ -1,0 +1,151 @@
+use crate::*;
+
+impl Fbapi {
+    pub async fn post_ig_carousel(
+        &self,
+        access_token: &str,
+        account_igid: &str,
+        caption: &str,
+        children: &Vec<String>,
+        check_retry_count: usize,
+        check_video_delay: usize,
+        retry_count: usize,
+        log: impl Fn(LogParams),
+    ) -> Result<serde_json::Value, FbapiError> {
+        let creation_id = post(
+            &self.make_path(&format!("{}/media", account_igid)),
+            &access_token,
+            &caption,
+            &children,
+            retry_count,
+            &self.client,
+            &log,
+        )
+        .await?;
+
+        check_loop(
+            &self.make_path(&format!(
+                "{}?fields=status_code&access_token={}",
+                creation_id, access_token
+            )),
+            check_retry_count,
+            check_video_delay,
+            retry_count,
+            &self.client,
+            &log,
+        )
+        .await?;
+
+        publish(
+            &self.make_path(&format!("{}/media_publish", account_igid)),
+            &access_token,
+            &creation_id,
+            retry_count,
+            &self.client,
+            &log,
+        )
+        .await
+    }
+}
+
+async fn post(
+    path: &str,
+    access_token: &str,
+    caption: &str,
+    children: &Vec<String>,
+    retry_count: usize,
+    client: &reqwest::Client,
+    log: impl Fn(LogParams),
+) -> Result<String, FbapiError> {
+    let children_str = &children.join(",");
+    let params = vec![
+        ("access_token", access_token),
+        ("media_type", "CAROUSEL"),
+        ("children", children_str),
+        ("caption", caption),
+    ];
+    let log_params = LogParams::new(&path, &params);
+    let res = execute_retry(
+        retry_count,
+        || async {
+            client
+                .post(path)
+                .form(&params)
+                .send()
+                .await
+                .map_err(|e| e.into())
+        },
+        &log,
+        log_params,
+    )
+    .await?;
+    match res["id"].as_str() {
+        Some(s) => Ok(s.to_owned()),
+        None => return Err(FbapiError::UnExpected(res)),
+    }
+}
+
+async fn check(
+    path: &str,
+    retry_count: usize,
+    client: &reqwest::Client,
+    log: &impl Fn(LogParams),
+) -> Result<String, FbapiError> {
+    let log_params = LogParams::new(&path, &vec![]);
+    let res = execute_retry(
+        retry_count,
+        || async { client.get(path).send().await.map_err(|e| e.into()) },
+        log,
+        log_params,
+    )
+    .await?;
+    match res["status_code"].as_str() {
+        Some(s) => Ok(s.to_owned()),
+        None => return Err(FbapiError::UnExpected(res)),
+    }
+}
+
+async fn check_loop(
+    path: &str,
+    check_retry_count: usize,
+    check_video_delay: usize,
+    retry_count: usize,
+    client: &reqwest::Client,
+    log: &impl Fn(LogParams),
+) -> Result<(), FbapiError> {
+    for _ in 0..check_retry_count {
+        match check(path, retry_count, client, log).await?.as_str() {
+            "FINISHED" => return Ok(()),
+            "IN_PROGRESS" => {}
+            _ => return Err(FbapiError::VideoError),
+        }
+        sleep(check_video_delay).await;
+    }
+    Err(FbapiError::VideoTimeout)
+}
+
+async fn publish(
+    path: &str,
+    access_token: &str,
+    creation_id: &str,
+    retry_count: usize,
+    client: &reqwest::Client,
+    log: impl Fn(LogParams),
+) -> Result<serde_json::Value, FbapiError> {
+    let params = vec![("access_token", access_token), ("creation_id", creation_id)];
+    let log_params = LogParams::new(&path, &params);
+    execute_retry(
+        retry_count,
+        || async {
+            client
+                .post(path)
+                .form(&params)
+                .send()
+                .await
+                .map_err(|e| e.into())
+        },
+        &log,
+        log_params,
+    )
+    .await
+}

--- a/src/apis/post_ig_carousel.rs
+++ b/src/apis/post_ig_carousel.rs
@@ -37,12 +37,11 @@ impl Fbapi {
         )
         .await?;
 
-        publish(
-            &self.make_path(&format!("{}/media_publish", account_igid)),
+        self.post_ig_media_publish(
             &access_token,
+            &account_igid,
             &creation_id,
             retry_count,
-            &self.client,
             &log,
         )
         .await

--- a/src/apis/post_ig_media_publish.rs
+++ b/src/apis/post_ig_media_publish.rs
@@ -1,0 +1,48 @@
+use crate::*;
+
+impl Fbapi {
+    pub async fn post_ig_media_publish(
+        &self,
+        access_token: &str,
+        account_igid: &str,
+        creation_id: &str,
+        retry_count: usize,
+        log: impl Fn(LogParams),
+    ) -> Result<serde_json::Value, FbapiError> {
+        post(
+            &self.make_path(&format!("{}/media_publish", account_igid)),
+            &access_token,
+            &creation_id,
+            retry_count,
+            &self.client,
+            &log,
+        )
+        .await
+    }
+}
+
+async fn post(
+    path: &str,
+    access_token: &str,
+    creation_id: &str,
+    retry_count: usize,
+    client: &reqwest::Client,
+    log: impl Fn(LogParams),
+) -> Result<serde_json::Value, FbapiError> {
+    let params = vec![("access_token", access_token), ("creation_id", creation_id)];
+    let log_params = LogParams::new(&path, &params);
+    execute_retry(
+        retry_count,
+        || async {
+            client
+                .post(path)
+                .form(&params)
+                .send()
+                .await
+                .map_err(|e| e.into())
+        },
+        &log,
+        log_params,
+    )
+    .await
+}

--- a/src/apis/post_ig_picture.rs
+++ b/src/apis/post_ig_picture.rs
@@ -22,12 +22,11 @@ impl Fbapi {
         )
         .await?;
 
-        publish(
-            &self.make_path(&format!("{}/media_publish", account_igid)),
+        self.post_ig_media_publish(
             &access_token,
+            &account_igid,
             &creation_id,
             retry_count,
-            &self.client,
             &log,
         )
         .await
@@ -97,30 +96,4 @@ async fn post(
         Some(s) => Ok(s.to_owned()),
         None => return Err(FbapiError::UnExpected(res)),
     }
-}
-
-async fn publish(
-    path: &str,
-    access_token: &str,
-    creation_id: &str,
-    retry_count: usize,
-    client: &reqwest::Client,
-    log: impl Fn(LogParams),
-) -> Result<serde_json::Value, FbapiError> {
-    let params = vec![("access_token", access_token), ("creation_id", creation_id)];
-    let log_params = LogParams::new(&path, &params);
-    execute_retry(
-        retry_count,
-        || async {
-            client
-                .post(path)
-                .form(&params)
-                .send()
-                .await
-                .map_err(|e| e.into())
-        },
-        &log,
-        log_params,
-    )
-    .await
 }

--- a/src/apis/post_ig_picture.rs
+++ b/src/apis/post_ig_picture.rs
@@ -15,6 +15,7 @@ impl Fbapi {
             &access_token,
             &image_url,
             &caption,
+            false,
             retry_count,
             &self.client,
             &log,
@@ -31,6 +32,30 @@ impl Fbapi {
         )
         .await
     }
+
+    // Return container id when success
+    pub async fn post_ig_image_container(
+        &self,
+        access_token: &str,
+        account_igid: &str,
+        image_url: &str,
+        caption: &str,
+        is_carousel_item: bool,
+        retry_count: usize,
+        log: impl Fn(LogParams),
+    ) -> Result<String, FbapiError> {
+        post(
+            &self.make_path(&format!("{}/media", account_igid)),
+            &access_token,
+            &image_url,
+            &caption,
+            is_carousel_item,
+            retry_count,
+            &self.client,
+            &log,
+        )
+        .await
+    }
 }
 
 async fn post(
@@ -38,6 +63,7 @@ async fn post(
     access_token: &str,
     image_url: &str,
     caption: &str,
+    is_carousel_item: bool,
     retry_count: usize,
     client: &reqwest::Client,
     log: impl Fn(LogParams),
@@ -46,7 +72,12 @@ async fn post(
         ("access_token", access_token),
         ("image_url", image_url),
         ("caption", caption),
+        (
+            "is_carousel_item",
+            if is_carousel_item { "true" } else { "false" },
+        ),
     ];
+
     let log_params = LogParams::new(&path, &params);
     let res = execute_retry(
         retry_count,

--- a/src/apis/post_ig_video.rs
+++ b/src/apis/post_ig_video.rs
@@ -38,12 +38,11 @@ impl Fbapi {
         )
         .await?;
 
-        publish(
-            &self.make_path(&format!("{}/media_publish", account_igid)),
+        self.post_ig_media_publish(
             &access_token,
+            &account_igid,
             &creation_id,
             retry_count,
-            &self.client,
             &log,
         )
         .await
@@ -130,30 +129,4 @@ async fn post(
         Some(s) => Ok(s.to_owned()),
         None => return Err(FbapiError::UnExpected(res)),
     }
-}
-
-async fn publish(
-    path: &str,
-    access_token: &str,
-    creation_id: &str,
-    retry_count: usize,
-    client: &reqwest::Client,
-    log: impl Fn(LogParams),
-) -> Result<serde_json::Value, FbapiError> {
-    let params = vec![("access_token", access_token), ("creation_id", creation_id)];
-    let log_params = LogParams::new(&path, &params);
-    execute_retry(
-        retry_count,
-        || async {
-            client
-                .post(path)
-                .form(&params)
-                .send()
-                .await
-                .map_err(|e| e.into())
-        },
-        &log,
-        log_params,
-    )
-    .await
 }

--- a/src/apis/post_ig_video.rs
+++ b/src/apis/post_ig_video.rs
@@ -1,3 +1,4 @@
+use crate::apis::check_ig_media::check_ig_media_loop;
 use crate::*;
 
 impl Fbapi {
@@ -24,7 +25,7 @@ impl Fbapi {
         )
         .await?;
 
-        check_loop(
+        check_ig_media_loop(
             &self.make_path(&format!(
                 "{}?fields=status_code&access_token={}",
                 creation_id, access_token
@@ -73,7 +74,7 @@ impl Fbapi {
         )
         .await?;
 
-        check_loop(
+        check_ig_media_loop(
             &self.make_path(&format!(
                 "{}?fields=status_code&access_token={}",
                 container_id, access_token
@@ -129,45 +130,6 @@ async fn post(
         Some(s) => Ok(s.to_owned()),
         None => return Err(FbapiError::UnExpected(res)),
     }
-}
-
-async fn check(
-    path: &str,
-    retry_count: usize,
-    client: &reqwest::Client,
-    log: &impl Fn(LogParams),
-) -> Result<String, FbapiError> {
-    let log_params = LogParams::new(&path, &vec![]);
-    let res = execute_retry(
-        retry_count,
-        || async { client.get(path).send().await.map_err(|e| e.into()) },
-        log,
-        log_params,
-    )
-    .await?;
-    match res["status_code"].as_str() {
-        Some(s) => Ok(s.to_owned()),
-        None => return Err(FbapiError::UnExpected(res)),
-    }
-}
-
-async fn check_loop(
-    path: &str,
-    check_retry_count: usize,
-    check_video_delay: usize,
-    retry_count: usize,
-    client: &reqwest::Client,
-    log: &impl Fn(LogParams),
-) -> Result<(), FbapiError> {
-    for _ in 0..check_retry_count {
-        match check(path, retry_count, client, log).await?.as_str() {
-            "FINISHED" => return Ok(()),
-            "IN_PROGRESS" => {}
-            _ => return Err(FbapiError::VideoError),
-        }
-        sleep(check_video_delay).await;
-    }
-    Err(FbapiError::VideoTimeout)
 }
 
 async fn publish(

--- a/src/apis/post_video.rs
+++ b/src/apis/post_video.rs
@@ -35,15 +35,16 @@ impl Fbapi {
             &log,
         )
         .await?;
-        
+
         // サムネルがあれば、サムネル設定します。
         match thumb {
             Some(bytes) => {
-                self.post_video_thumnail(access_token, &fbid, bytes, &log).await?;
-            },
+                self.post_video_thumnail(access_token, &fbid, bytes, &log)
+                    .await?;
+            }
             None => {}
         };
-        
+
         post(
             &self.make_path(&fbid),
             access_token,
@@ -90,12 +91,13 @@ impl Fbapi {
             &log,
         )
         .await?;
-        
+
         // サムネルがあれば、サムネル設定します。
         match thumb {
             Some(bytes) => {
-                self.post_video_thumnail(access_token, &fbid, bytes, &log).await?;
-            },
+                self.post_video_thumnail(access_token, &fbid, bytes, &log)
+                    .await?;
+            }
             None => {}
         };
 

--- a/src/apis/post_video_thumnail.rs
+++ b/src/apis/post_video_thumnail.rs
@@ -10,10 +10,7 @@ impl Fbapi {
         log: impl Fn(LogParams),
     ) -> Result<serde_json::Value, FbapiError> {
         let path = self.make_path(&format!("{}/thumbnails", video_id));
-        let params = vec![
-            ("access_token", access_token),
-            ("video_id", video_id),
-        ];
+        let params = vec![("access_token", access_token), ("video_id", video_id)];
         let log_params = LogParams::new(&path, &params);
         let part = make_part("thumnail", bytes)?;
         let form = Form::new()


### PR DESCRIPTION
コミットごとに修正をある程度纏めているので、ログを参考にコードを確認していただければと思います。

主に実装したかっった事は、画像コンテナと動画コンテナの作成とカルーセルの公開です。

- [Meta - メディアAPIについて](https://developers.facebook.com/docs/instagram-api/reference/ig-user/media#--)

画像もしくは動画を投稿するために使う、既存の `post_ig_picuture` と `post_ig_video` メソッドはコンテナの作成とメディア公開を同時に実行しますが、カルーセル投稿は画像・動画コンテナを作成したうえで、カルーセル投稿を作成する必要があります。そのため専用のメソッドを既存の処理から切り出しています。

それにあたり共通部分がいくつか発生したため、コードの整理もしました。