### PR TITLE
Instagramリール投稿に対応

### DIFF
--- a/src/apis.rs
+++ b/src/apis.rs
@@ -8,6 +8,7 @@ pub mod post_feed_array;
 pub mod post_ig_carousel;
 pub mod post_ig_media_publish;
 pub mod post_ig_picture;
+pub mod post_ig_reel;
 pub mod post_ig_video;
 pub mod post_object;
 pub mod post_picture;

--- a/src/apis/post_ig_carousel.rs
+++ b/src/apis/post_ig_carousel.rs
@@ -26,7 +26,7 @@ impl Fbapi {
 
         check_ig_media_loop(
             &self.make_path(&format!(
-                "{}?fields=status_code&access_token={}",
+                "{}?fields=status,status_code&access_token={}",
                 creation_id, access_token
             )),
             check_retry_count,

--- a/src/apis/post_ig_reel.rs
+++ b/src/apis/post_ig_reel.rs
@@ -1,0 +1,92 @@
+use crate::apis::check_ig_media::check_ig_media_loop;
+use crate::*;
+
+impl Fbapi {
+    pub async fn post_ig_reel(
+        &self,
+        access_token: &str,
+        account_igid: &str,
+        video_url: &str,
+        caption: &str,
+        is_share_to_feed: bool,
+        check_retry_count: usize,
+        check_video_delay: usize,
+        retry_count: usize,
+        log: impl Fn(LogParams),
+    ) -> Result<serde_json::Value, FbapiError> {
+        let creation_id = post(
+            &self.make_path(&format!("{}/media", account_igid)),
+            &access_token,
+            &video_url,
+            &caption,
+            is_share_to_feed,
+            retry_count,
+            &self.client,
+            &log,
+        )
+        .await?;
+
+        check_ig_media_loop(
+            &self.make_path(&format!(
+                "{}?fields=status_code&access_token={}",
+                creation_id, access_token
+            )),
+            check_retry_count,
+            check_video_delay,
+            retry_count,
+            &self.client,
+            &log,
+        )
+        .await?;
+
+        self.post_ig_media_publish(
+            &access_token,
+            &account_igid,
+            &creation_id,
+            retry_count,
+            &log,
+        )
+        .await
+    }
+}
+
+async fn post(
+    path: &str,
+    access_token: &str,
+    video_url: &str,
+    caption: &str,
+    is_share_to_feed: bool,
+    retry_count: usize,
+    client: &reqwest::Client,
+    log: impl Fn(LogParams),
+) -> Result<String, FbapiError> {
+    let params = vec![
+        ("access_token", access_token),
+        ("media_type", "REELS"),
+        ("video_url", video_url),
+        ("caption", caption),
+        (
+            "share_to_feed",
+            if is_share_to_feed { "true" } else { "false" },
+        ),
+    ];
+    let log_params = LogParams::new(&path, &params);
+    let res = execute_retry(
+        retry_count,
+        || async {
+            client
+                .post(path)
+                .form(&params)
+                .send()
+                .await
+                .map_err(|e| e.into())
+        },
+        &log,
+        log_params,
+    )
+    .await?;
+    match res["id"].as_str() {
+        Some(s) => Ok(s.to_owned()),
+        None => return Err(FbapiError::UnExpected(res)),
+    }
+}

--- a/src/apis/post_ig_reel.rs
+++ b/src/apis/post_ig_reel.rs
@@ -28,7 +28,7 @@ impl Fbapi {
 
         check_ig_media_loop(
             &self.make_path(&format!(
-                "{}?fields=status_code&access_token={}",
+                "{}?fields=status,status_code&access_token={}",
                 creation_id, access_token
             )),
             check_retry_count,

--- a/src/apis/post_ig_video.rs
+++ b/src/apis/post_ig_video.rs
@@ -27,7 +27,7 @@ impl Fbapi {
 
         check_ig_media_loop(
             &self.make_path(&format!(
-                "{}?fields=status_code&access_token={}",
+                "{}?fields=status,status_code&access_token={}",
                 creation_id, access_token
             )),
             check_retry_count,
@@ -75,7 +75,7 @@ impl Fbapi {
 
         check_ig_media_loop(
             &self.make_path(&format!(
-                "{}?fields=status_code&access_token={}",
+                "{}?fields=status,status_code&access_token={}",
                 container_id, access_token
             )),
             check_retry_count,

--- a/src/error.rs
+++ b/src/error.rs
@@ -15,14 +15,17 @@ pub enum FbapiError {
     #[error(transparent)]
     IO(#[from] std::io::Error),
 
-    #[error("Faecbook unexpected json: {0}")]
+    #[error("Facebook unexpected json: {0}")]
     UnExpected(serde_json::Value),
 
-    #[error("Faecbook viedo error")]
+    #[error("Facebook viedo error")]
     VideoError,
 
-    #[error("Faecbook viedo check loop timeout error")]
+    #[error("Facebook viedo check loop timeout error")]
     VideoTimeout,
+
+    #[error("Instagram viedo error: {0}")]
+    IgVideoError(serde_json::Value),
 }
 
 // ユーザに表示するエラー内容


### PR DESCRIPTION
# Instagramリール投稿

リール投稿に対応しました。アップロード後、ポーリングして状況を確認するなど基本は動画投稿ですが、 `share_to_feed` を始め微妙にパラメータが異なります。

7348a2345b91a6a5029408aa5750ccbb8fd63a94

# Instagramの動画アップロード後のエラー内容が取得できるように

動画アップロード後、定期的に状況を取得する関数`check_ig_media_loop` でエラーが発生したときに、APIで返却されるエラー内容を取得していなかったため、フィールドを追加し新しいInstagram動画エラーで内容を確認できるようにしました。

c0215390a39f8ff39f74a0b8ee645f85f8d170a3
