### PR TITLE
dependencies were upgraded

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,11 +7,11 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-once_cell = "~1.5.2"
-reqwest = { version = "~0.10", features = ["json", "stream"] }
+once_cell = "~1.17.1"
+reqwest = { version = "~0.11", features = ["json", "stream", "multipart"] }
 rust-crypto = "~0.2.36"
 serde = { version = "~1.0", features = ["derive"] }
 serde_json = "~1.0"
-rusoto_core = "~0.45.0"
-thiserror = "~1.0.23"
-tokio = { version = "~0.2", features = ["macros", "time"] }
+rusoto_core = "~0.46.0"
+thiserror = "~1.0"
+tokio = { version = "~1", features = ["macros", "time"] }

--- a/src/apis/check_ig_media.rs
+++ b/src/apis/check_ig_media.rs
@@ -36,7 +36,7 @@ pub(crate) async fn check_ig_media_loop(
             "IN_PROGRESS" => {}
             _ => return Err(FbapiError::IgVideoError(res)),
         }
-        sleep(check_video_delay).await;
+        sleep_sec(check_video_delay).await;
     }
     Err(FbapiError::VideoTimeout)
 }

--- a/src/apis/post_video.rs
+++ b/src/apis/post_video.rs
@@ -251,7 +251,7 @@ async fn check_loop(
             "processing" => {}
             _ => return Err(FbapiError::VideoError),
         }
-        sleep(check_video_delay).await;
+        sleep_sec(check_video_delay).await;
     }
     Err(FbapiError::VideoTimeout)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ use crypto::mac::Mac;
 use once_cell::sync::Lazy;
 use reqwest::{multipart::Part, Body};
 use std::{future::Future, time::Duration};
-use tokio::time::delay_for;
+use tokio::time::sleep;
 
 pub use reqwest;
 
@@ -169,8 +169,8 @@ pub(crate) fn make_part(path: &str, bytes: rusoto_core::ByteStream) -> Result<Pa
         .map_err(|e| e.into())
 }
 
-pub(crate) async fn sleep(seconds: usize) {
-    delay_for(Duration::from_secs(seconds as u64)).await
+pub(crate) async fn sleep_sec(seconds: usize) {
+    sleep(Duration::from_secs(seconds as u64)).await
 }
 
 #[cfg(test)]


### PR DESCRIPTION
- tokioのバージョンが最新(v1.25.0)になるように依存パッケージをバージョンアップしました。
- tokio::time::delay_forがなくなっていたのでtokio::time::sleepに置き換えました