### PR TITLE
Migration host upload video url graph-api

### DIFF
--- a/src/apis/post_video.rs
+++ b/src/apis/post_video.rs
@@ -15,7 +15,7 @@ impl Fbapi {
         log: impl Fn(LogParams),
     ) -> Result<serde_json::Value, FbapiError> {
         let fbid = video(
-            &self.make_video_path(&format!("{}/videos", page_fbid)),
+            &self.make_path(&format!("{}/videos", page_fbid)),
             access_token,
             url,
             description,
@@ -71,7 +71,7 @@ impl Fbapi {
         log: impl Fn(LogParams),
     ) -> Result<serde_json::Value, FbapiError> {
         let fbid = video(
-            &self.make_video_path(&format!("{}/videos", page_fbid)),
+            &self.make_path(&format!("{}/videos", page_fbid)),
             access_token,
             url,
             description,


### PR DESCRIPTION
Ticket info : https://github.com/UniqueVision/beluga_studio.beluga_studio/issues/16807#issue-3392399156
Facebook は、host graph-video.facebook.com を graph.facebook.com に強制的に変更しました。
https://developers.facebook.com/docs/video-api/overview?locale=en_US#:~:text=The%20graph%2Dvideo.facebook.com%20host%20for%20video%20uploads%20has%20been%20deprecated.%20Use%20the%20graph.facebook.com%20host%20for%20API%20requests%20when%20uploading%20videos%20to%20Meta%20servers.