### PR TITLE
feat: メディアID検証機能を追加

### DIFF
--- a/src/apis/post_ig_carousel.rs
+++ b/src/apis/post_ig_carousel.rs
@@ -1,4 +1,5 @@
 use crate::apis::check_ig_media::check_ig_media_loop;
+use crate::validate_media_id;
 use crate::*;
 
 impl Fbapi {
@@ -109,8 +110,8 @@ async fn post(
     )
     .await?;
     match res["id"].as_str() {
-        Some(s) => Ok(s.to_owned()),
-        None => return Err(FbapiError::UnExpected(res)),
+        Some(s) => validate_media_id(s, &res),
+        None => Err(FbapiError::UnExpected(res)),
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -35,6 +35,12 @@ pub enum FbapiError {
 
     #[error("Facebook upload reel not started after phase published")]
     UploadReelNotStarted,
+
+    #[error("Invalid media ID: {id} (response: {response})")]
+    InvalidMediaId {
+        id: String,
+        response: serde_json::Value,
+    },
 }
 
 // ユーザに表示するエラー内容

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -190,7 +190,10 @@ impl LogParams {
 /// Validates that a media ID is a valid non-zero numeric string.
 ///
 /// Returns an error if the ID is empty, "0", or contains non-digit characters.
-pub fn validate_media_id(id: &str, response: &serde_json::Value) -> Result<String, FbapiError> {
+pub(crate) fn validate_media_id(
+    id: &str,
+    response: &serde_json::Value,
+) -> Result<String, FbapiError> {
     if id.is_empty() || id == "0" || !id.chars().all(|c| c.is_ascii_digit()) {
         return Err(FbapiError::InvalidMediaId {
             id: id.to_owned(),


### PR DESCRIPTION
- InvalidMediaIdエラーバリアントを追加
- validate_media_id関数で空文字、"0"、非数値文字を検出
- IGカルーセル投稿時のID検証を実装
- レートリミットヘッダー(x-app-usage, x-business-use-case-usage)の抽出を追加